### PR TITLE
Move "Changelog to support" to the reminder list

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,14 +10,11 @@ Please fill me in.
 
 Specs? Manual steps? Please fill me in.
 
-### Changelog to support
-
-Please fill me in.
-
 ---
 
 Friendly reminders
 
 - Include reference to Trello (or possibly Slack)
+- Include changelog to support if applicable
 - Lint rules pass
 - The environment (`heroku config`) has been updated if needed (new `ENV` variables)


### PR DESCRIPTION
### WHY are these changes introduced?

More times than not the changes have nothing interesting for the support team so to streamline the PR work a bit, let's remove the "requirement" on it.

### WHAT is this pull request doing?

Moving "Changelog to support" to the reminder list

### HOW can this pull request be tested?

Create a new organization, add this PR template and open a PR or trust your markdown skills 😂.

### Changelog to support

N/A!!!!!!!!!

---

Author's note, mindf*ck to update the PR template in a PR and being presented with the old template.

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)
