### PR TITLE
Reminders as comments

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,7 @@ Please fill me in.
 
 Specs? Manual steps? Please fill me in.
 
----
+<!---
 
 Friendly reminders
 
@@ -18,3 +18,5 @@ Friendly reminders
 - Include changelog to support if applicable
 - Lint rules pass
 - The environment (`heroku config`) has been updated if needed (new `ENV` variables)
+
+-->


### PR DESCRIPTION
### WHY are these changes introduced?

Curious on how this gets rendered and whether it makes it easier to copy+paste to commit message, also should make the PR description somewhat easier to read as it won't show the reminders

### WHAT is this pull request doing?

Changing reminders to be in "commented out".

### HOW can this pull request be tested?

Open a PR on a 84codes repo after this has been merged.

<!---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
